### PR TITLE
ci: use a GitHub App token for the issues board

### DIFF
--- a/.github/workflows/add_issues_to_kanban.yml
+++ b/.github/workflows/add_issues_to_kanban.yml
@@ -1,0 +1,22 @@
+name: Add issues to the user issues board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.PROJECT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.PROJECT_BOT_PRIVATE_KEY }}
+      - uses: actions/add-to-project@v2.0.0
+        with:
+          project-url: https://github.com/orgs/DeepL/projects/1
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
New issues in this repo do not reach the user issues board. The SDK repos have this workflow already, this one does not.

The workflow adds every newly opened issue to the board. It mints a short-lived installation token from the `deepl-oss-project-bot` App, so there is no credential to rotate.

The org secrets `PROJECT_BOT_CLIENT_ID` and `PROJECT_BOT_PRIVATE_KEY` are already in place for this repo.
